### PR TITLE
Use known_hosts module to avoid race condition

### DIFF
--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -42,17 +42,12 @@
   delegate_to: localhost
   register: reset
 
-- name: Check that known_hosts file exists
-  stat:
-    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
-  delegate_to: localhost
-  register: stat_known_hosts_result
-
 - name: remove server from local known_hosts file
-  command: ssh-keygen -R {{ ansible_host }}
+  known_hosts:
+    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+    name: "{{ ansible_host }}"
+    state: absent
   delegate_to: localhost
-  changed_when: true
-  when: stat_known_hosts_result.stat.exists
 
 - name: pause a bit for the hardware reset to kick in
   pause:

--- a/tasks/rescuemode.yml
+++ b/tasks/rescuemode.yml
@@ -47,17 +47,12 @@
   delegate_to: localhost
   register: reset
 
-- name: Check that known_hosts file exists
-  stat:
-    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
-  delegate_to: localhost
-  register: stat_known_hosts_result
-
 - name: remove server from local known_hosts file
-  command: ssh-keygen -R {{ ansible_host }}
+  known_hosts:
+    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+    name: "{{ ansible_host }}"
+    state: absent
   delegate_to: localhost
-  changed_when: false
-  when: stat_known_hosts_result.stat.exists
 
 - name: pause a bit for the hardware reset to kick in
   pause:


### PR DESCRIPTION
`ssh-keygen -R` failed occasionally. Using the module should take care of the race condition by leveraging the ansible file locking mechanism.