### PR TITLE
only use apt for debian and ubuntu distros

### DIFF
--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -62,6 +62,14 @@
     timeout: 180
   delegate_to: localhost
 
+- name: get os-release id
+  raw: . /etc/os-release; echo $ID
+  register: osrelease
+
+- name: trim os-release id
+  set_fact:
+    osrelease: "{{ osrelease.stdout | trim }}"
+
 # uses raw instead of module as python might not be installed yet
 - name: update apt repositories
   raw: apt-get update
@@ -70,11 +78,13 @@
   delay: 5
   register: update_apt
   until: update_apt.rc == 0
+  when: osrelease in ["debian", "ubuntu"]
 
 # uses raw instead of module as python might not be installed yet
 - name: install python on remote host
   raw: apt-get install python -y
   changed_when: true
+  when: osrelease in ["debian", "ubuntu"]
 
 - name: Lookup content of installimage config file
   set_fact:

--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -64,6 +64,7 @@
 
 - name: get os-release id
   raw: . /etc/os-release; echo $ID
+  changed_when: false
   register: osrelease
 
 - name: trim os-release id


### PR DESCRIPTION
currently rpm based distros do not work as they do not support apt.
This patch solves this by querying the distro as defined in /etc/os-release.