### PR TITLE
hetzner_installimage_skip_confirmation must be set to yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ operating system usually have no ssh access configured and `gather_facts` will d
 See more examples in the playbooks of the different test scenarios inside the test folder.
 
 The role will ask for a confirmation from the user to wipe all data for all hosts in the play. This can be overwritten
-by using the variable `hetzner_installimage_skip_confirmation` set to `y`.
+by using the variable `hetzner_installimage_skip_confirmation` set to `yes`.
 
 An example for the extra vars would look like this:
 


### PR DESCRIPTION
File: `tasks/main.yml`

In the documentation is written:
`This can be overwritten by using the variable hetzner_installimage_skip_confirmation set to y.`

At least for me, this is not working. I had to fill in  `yes` 
Additionally, when I check the prompt in `Confirm OS image installation` and the `set_fact` 
`hetzner_installimage_run: "{{ confirm_installation.user_input | default(hetzner_installimage_skip_confirmation) | bool }}"`
`yes` should be correct and `y` leads to a wrong behavior.

Just a little issue but the docs should be upgraded