### PR TITLE
Fix fails on CentOS 8 install with cached discovered_interpreter_python

### DIFF
--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -62,6 +62,9 @@
     timeout: 180
   delegate_to: localhost
 
+- name: Clear cached installimage facts
+  meta: clear_facts
+
 - name: Check is apt-get installed
   raw: command -v apt-get >/dev/null 2>&1
   changed_when: false


### PR DESCRIPTION
installimage tasks puts into cached facts
discovered_interpreter_python: /usr/bin/python

After reboot with installed CentOS 8, cached value of the discovered_interpreter_python becoms not valid.
We need to clean facts cache to get correct discovered_interpreter_python:
discovered_interpreter_python: /usr/libexec/platform-python